### PR TITLE
Added 'tools' parameter to override tools in Environment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,7 +1,8 @@
 
 import os, sys
 
-env = Environment(ENV = { "PATH" : os.environ["PATH"],
+env = Environment(tools = [*filter(None, ARGUMENTS.get('tools','').split(','))] or None,
+                  ENV = { "PATH" : os.environ["PATH"],
                           "HOME" : os.environ["HOME"] })
 env["CXXFLAGS"] = Split("-Wall -std=c++11 -Isrc")
 env.Append(CXXFLAGS = Split("-march=sandybridge -mtune=generic"))


### PR DESCRIPTION
This may be needed to force use of MinGW on systems where both MinGW and Visual Studio are installed.  Otherwise, even when scons is run from the MinGW shell, it defaults to using Visual Studio if available.

In those cases, running `scons tools=mingw` will cause the desired toolchain to be used.