### PR TITLE
Clarified error to be more descriptive of the problem.

### DIFF
--- a/src/landdata.cpp
+++ b/src/landdata.cpp
@@ -329,7 +329,7 @@ void LandscapeData::loadESMFile(ESMFile& esmFile,
     cellMaxY = (y > cellMaxY ? y : cellMaxY);
   }
   if (!(cellMaxX >= cellMinX && cellMaxY >= cellMinY))
-    errorMessage("LandscapeData: world not found in ESM file");
+    errorMessage("LandscapeData: landscape data not found for world in ESM file");
   allocateDataBuf(formatMask, false);
   std::map< unsigned int, unsigned int >  emptyCells;
   std::map< unsigned int, float > cellHeightOffsets;


### PR DESCRIPTION
The error condition being signaled here is not that the world (WRLD record) isn't found in the ESM file, but that there are no LAND records associated with that world.  The absence of the world itself is checked for and reported elsewhere, but the same error text was being used in both places.

Since Fallout 76 does not use LAND records at all in its .ESM files, this message is a common one to receive if one doesn't specify external landscape data.