### PR TITLE
macOS build and render fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Can be built with MSYS2 (https://www.msys2.org/) on 64-bit Windows, and also on 
 * By default, the code generated is compatible with Intel Sandy Bridge or newer CPUs. Adding **avx=0** or **avx2=1** disables instruction set extensions or also enables them for Haswell or newer, respectively.
 * Optionally, for the makemap and icon extraction scripts only, download and install [ImageMagick](https://imagemagick.org/script/download.php#windows) and [SWFTools](http://www.swftools.org/download.html).
 
+### Building the source code on macOS
+
+* Install Xcode from the App Store.
+* Install the Xcode command line tools by running **xcode-select --install** in the terminal.
+* Install [Homebrew](https://brew.sh/).
+* Install the required packages with **brew install scons sdl2 swig**.
+* Use the same **scons -j 8** command to compile the utilities.
+* Optionally, with Apple Silicon, you can use "apple-m1=1" or "apple-m2=1" to enable the M1 or M2 architecture, respectively.
+
 #### Example 1
 
     ./btddump Fallout76/Data/Terrain/Appalachia.btd fo76hmap.dds 0 -80 -80 80 80 1

--- a/SConstruct
+++ b/SConstruct
@@ -7,11 +7,25 @@ env = Environment(tools = [*filter(None, ARGUMENTS.get('tools','').split(','))] 
 env["CCFLAGS"] = Split("-Wall -Isrc -Ilibfo76utils/src")
 env["CFLAGS"] = Split("-std=c99")
 env["CXXFLAGS"] = Split("-std=c++20")
-if int(ARGUMENTS.get("avx2", 0)):
-    env.Append(CCFLAGS = ["-march=haswell"])
-elif int(ARGUMENTS.get("avx", 1)):
-    env.Append(CCFLAGS = ["-march=sandybridge"])
-env.Append(CCFLAGS = ["-mtune=generic"])
+
+arch = os.uname().machine
+if arch == "arm64":
+    if "darwin" in sys.platform:
+        if int(ARGUMENTS.get("apple-m1", 0)):
+            env.Append(CCFLAGS = ["-mcpu=apple-m1"])
+        elif int(ARGUMENTS.get("apple-m2", 0)):
+            env.Append(CCFLAGS = ["-mcpu=apple-m2"])
+        else:
+            env.Append(CCFLAGS = ["-arch", "arm64"])
+    else:
+        env.Append(CCFLAGS = ["-arch", "arm64"])
+else:
+    if int(ARGUMENTS.get("avx2", 0)):
+        env.Append(CCFLAGS = ["-march=haswell"])
+    elif int(ARGUMENTS.get("avx", 1)):
+        env.Append(CCFLAGS = ["-march=sandybridge"])
+    env.Append(CCFLAGS = ["-mtune=generic"])
+
 env.Append(LIBS = ["m"])
 if "win" in sys.platform:
     buildPackage = ARGUMENTS.get("buildpkg", "")

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -1826,13 +1826,23 @@ void Renderer::renderObject(RenderThread& t, const RenderObject& p)
       {
         FloatVector4  zMax(0.0f);
         const float *zPtr = outBufZ + (size_t(y) * size_t(width) + size_t(x0));
+        if (zPtr == nullptr)
+          continue; // Skip to the next iteration if zPtr is invalid
         int     w = x1 + 1 - x0;
         for ( ; w >= 4; w = w - 4, zPtr = zPtr + 4)
+        {
+          if (zPtr < outBufZ || zPtr + 3 >= outBufZ + (size_t(width) * size_t(height)))
+            break; // Exit the loop if the pointer is out of bounds
           zMax.maxValues(FloatVector4(zPtr));
+        }
         zMax.maxValues(FloatVector4(zMax[1], zMax[0], zMax[3], zMax[2]));
         float   tmp = (zMax[0] > zMax[2] ? zMax[0] : zMax[2]);
         for ( ; w > 0; w--, zPtr++)
+        {
+          if (zPtr < outBufZ || zPtr >= outBufZ + (size_t(width) * size_t(height)))
+            break; // Exit the loop if the pointer is invalid
           tmp = (*zPtr > tmp ? *zPtr : tmp);
+        }
         if (tmp < b.zMin())
           continue;
         isVisible = true;


### PR DESCRIPTION
Hi! I'd like to use these tools on macOS, on Apple Silicon. To my surprise, it "just works", it's quite amazing. 😁 

I also ran into a couple of rendering issues that I've fixed. Please note that I have no real overview of the code base and just tried to skip rendering when pointer issues occur. It could be that this is inherent to how I used the tool, or there are more appropriate ways to tackle these, but nonetheless the changes resolved my issues.

For reference, this was the command that crashed before the changes:

```bash
./render /tmp/fo76/Content/Data/SeventySix.esm fo76_map_4k_4_11.dds 4096 4096 /tmp/fo76/Content/Data \
  -r -71 -71 71 71 \
  -light 1.7 70.5288 135 \
  -lcolor 1 0xFFFCF0 0.875 -1 -1 \
  -ltxtres 512 \
  -txtcache 32768 \
  -rq 271 \
  -ssaa 1 
  -xm swamptree \
  -view 0.25 180 0 0 20480 -8194 10240
```

Or the same with `-view 0.25 180 0 0 0 -4096 10240`.

I can add a workflow to create macOS artifacts, but I thought running this on macOS is kind of a niche use case, and didn't want to consume your minutes further with it.